### PR TITLE
add a required binding for more better feedback

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ require 'faker'
 puts "Starting to create site settings"
 puts "-------------------------------"
 
-SiteSetting.create(title: "Habdit", slogan: "Welcome to Chef Summit London 2017!")
+SiteSetting.create(title: "Habdit", slogan: "Reddit in Ruby on Rails in Habitat")
 
 puts "-------------------------------"
 puts "Finished to create stite settings"

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,1 +1,4 @@
 secret_key_base="fartmachine"
+
+site_title="Habdit"
+site_slogan="Welcome to Chef Summit 2017!"

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -5,28 +5,35 @@ source {{pkg.svc_config_path}}/app_env.sh
 
 export PGPASSWORD={{bind.database.first.cfg.superuser_password}}
 
+# create a user in postgresql for the web app if one doesn't exist
 hab pkg exec core/postgresql psql -h {{bind.database.first.sys.ip}} -U admin -d postgres -t -c "select usename from pg_user where usename = 'rordit';" | egrep .
 
 if [ $? -gt  0 ]; then
   hab pkg exec core/postgresql createuser -h {{bind.database.first.sys.ip}} -U {{bind.database.first.cfg.superuser_name}} rordit
 fi
 
+# always be updating the password for the app DB user
 hab pkg exec core/postgresql psql -h {{bind.database.first.sys.ip}} -U {{bind.database.first.cfg.superuser_name}} -c "ALTER USER rordit WITH PASSWORD 'rordit'" -d postgres
 
 
+# create a database for the application if one doesn't exist
 hab pkg exec core/postgresql psql -h {{bind.database.first.sys.ip}} -U admin -d postgres -t -c "select datname from pg_database where datname = 'rordit_production';" | egrep .
 
 if [ $? -gt 0 ]; then
   hab pkg exec core/postgresql createdb rordit_production -h {{bind.database.first.sys.ip}} -U {{bind.database.first.cfg.superuser_name}} -O rordit
 fi
 
+# create the directories to which the app expects to be able to write
 mkdir -p {{pkg.svc_var_path}}/tmp
 mkdir -p {{pkg.svc_var_path}}/log
 
+# migrate the database and set basic system settings
 hab pkg exec core/postgresql psql -h {{bind.database.first.sys.ip}} -U admin -d rordit_production -t -c "select title from site_settings;" | egrep .
 
 if [ $? -gt 0 ]; then
-  rordit-rake db:setup
+  rordit-rake db:migrate settings:create
+else
+  rordit-rake db:migrate
 fi
 
 

--- a/habitat/hooks/reconfigure
+++ b/habitat/hooks/reconfigure
@@ -1,0 +1,5 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+exec 2>&1
+
+source {{pkg.svc_config_path}}/app_env.sh
+rordit-rake settings:update

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -3,6 +3,11 @@ pkg_origin=core
 pkg_scaffolding="core/scaffolding-ruby"
 pkg_version="0.1.0"
 
+pkg_binds=(
+  [database]="port superuser_name superuser_password"
+)
+
 declare -A scaffolding_env
 scaffolding_env[SECRET_KEY_BASE]="{{cfg.secret_key_base}}"
-
+scaffolding_env[SITE_TITLE]="{{cfg.site_title}}"
+scaffolding_env[SITE_SLOGAN]="{{cfg.site_slogan}}"

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -1,7 +1,17 @@
 namespace :settings do
   desc "Create site setting and admin user"
   task create: :environment do
-    SiteSetting.create(title: "RoRdit", slogan: "Slogan is here.")
+    SiteSetting.create(title: "Habdit", slogan: "Reddit in Ruby on Rails in Habitat")
     AdminUser.create(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
+  end
+
+  task update: :environment do
+    title = ENV["SITE_TITLE"] || "Habdit"
+    slogan = ENV["SITE_SLOGAN"] || "Reddit in Ruby on Rails in Habitat"
+
+    site_setting = SiteSetting.first
+    site_setting.title = title
+    site_setting.slogan = slogan
+    site_setting.save
   end
 end


### PR DESCRIPTION
This bind totally makes things better by making the package bark at you
if you try to start the app without a database bind. It also means you
can start the app _with_ the bind _before_ you start the database and
the supervisor will wait until a database is up and ready.

Also adds a reconfigure hook for changing a site setting in the
database.